### PR TITLE
feat: retrieve cmd results in async mode with get_result command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ zemu_install: zemu_install_ironfish_link zemu_install_js_link
 
 .PHONY: zemu_test
 zemu_test:
-	cd $(TESTS_ZEMU_DIR) && yarn test -- --maxConcurrency 1
+	cd $(TESTS_ZEMU_DIR) && yarn test

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -26,7 +26,6 @@ pub fn accumulate_data(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> Resul
 
     // Append data to raw_tx
     ctx.buffer.set_slice(ctx.buffer.pos, data)?;
-    ctx.buffer.pos += data.len();
 
     // If we expect more chunks, return
     if chunk == 1 {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -12,8 +12,8 @@ mod dkg_round_1;
 mod dkg_round_2;
 mod dkg_round_3;
 mod dkg_sign;
-mod get_version;
 mod get_result;
+mod get_version;
 
 use dkg_backup_keys::handler_dkg_backup_keys;
 use dkg_commitments::handler_dkg_commitments;
@@ -26,8 +26,8 @@ use dkg_round_1::handler_dkg_round_1;
 use dkg_round_2::handler_dkg_round_2;
 use dkg_round_3::handler_dkg_round_3;
 use dkg_sign::handler_dkg_sign;
-use get_version::handler_get_version;
 use get_result::handler_get_result;
+use get_version::handler_get_version;
 
 pub fn handle_apdu(comm: &mut Comm, ins: &Instruction, ctx: &mut TxContext) -> Result<(), AppSW> {
     match ins {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13,6 +13,7 @@ mod dkg_round_2;
 mod dkg_round_3;
 mod dkg_sign;
 mod get_version;
+mod get_result;
 
 use dkg_backup_keys::handler_dkg_backup_keys;
 use dkg_commitments::handler_dkg_commitments;
@@ -26,6 +27,7 @@ use dkg_round_2::handler_dkg_round_2;
 use dkg_round_3::handler_dkg_round_3;
 use dkg_sign::handler_dkg_sign;
 use get_version::handler_get_version;
+use get_result::handler_get_result;
 
 pub fn handle_apdu(comm: &mut Comm, ins: &Instruction, ctx: &mut TxContext) -> Result<(), AppSW> {
     match ins {
@@ -40,10 +42,11 @@ pub fn handle_apdu(comm: &mut Comm, ins: &Instruction, ctx: &mut TxContext) -> R
         Instruction::DkgRound3 { chunk } => handler_dkg_round_3(comm, *chunk, ctx),
         Instruction::DkgCommitments { chunk } => handler_dkg_commitments(comm, *chunk, ctx),
         Instruction::DkgSign { chunk } => handler_dkg_sign(comm, *chunk, ctx),
-        Instruction::DkgGetKeys { key_type } => handler_dkg_get_keys(comm, key_type),
+        Instruction::DkgGetKeys { key_type } => handler_dkg_get_keys(comm, key_type, ctx),
         Instruction::DkgNonces { chunk } => handler_dkg_nonces(comm, *chunk, ctx),
-        Instruction::DkgGetPublicPackage => handler_dkg_get_public_package(comm),
-        Instruction::DkgBackupKeys => handler_dkg_backup_keys(comm),
+        Instruction::DkgGetPublicPackage => handler_dkg_get_public_package(comm, ctx),
+        Instruction::DkgBackupKeys => handler_dkg_backup_keys(comm, ctx),
         Instruction::DkgRestoreKeys { chunk } => handler_dkg_restore_keys(comm, *chunk, ctx),
+        Instruction::GetResult { chunk } => handler_get_result(comm, ctx, *chunk),
     }
 }

--- a/src/handlers/dkg_backup_keys.rs
+++ b/src/handlers/dkg_backup_keys.rs
@@ -15,12 +15,12 @@
  *  limitations under the License.
  *****************************************************************************/
 use crate::bolos::{zlog, zlog_stack};
+use crate::context::TxContext;
 use crate::crypto::chacha20poly::{compute_key, encrypt};
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW};
-use ledger_device_sdk::io::{Comm};
-use crate::context::TxContext;
 use crate::utils::response::save_result;
+use crate::AppSW;
+use ledger_device_sdk::io::Comm;
 
 #[inline(never)]
 pub fn handler_dkg_backup_keys(comm: &mut Comm, ctx: &mut TxContext) -> Result<(), AppSW> {

--- a/src/handlers/dkg_backup_keys.rs
+++ b/src/handlers/dkg_backup_keys.rs
@@ -17,14 +17,13 @@
 use crate::bolos::{zlog, zlog_stack};
 use crate::crypto::chacha20poly::{compute_key, encrypt};
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW, Instruction};
-use alloc::vec::Vec;
-use ledger_device_sdk::io::{Comm, Event};
-
-const MAX_APDU_SIZE: usize = 253;
+use crate::{AppSW};
+use ledger_device_sdk::io::{Comm};
+use crate::context::TxContext;
+use crate::utils::response::save_result;
 
 #[inline(never)]
-pub fn handler_dkg_backup_keys(comm: &mut Comm) -> Result<(), AppSW> {
+pub fn handler_dkg_backup_keys(comm: &mut Comm, ctx: &mut TxContext) -> Result<(), AppSW> {
     zlog("start handler_dkg_backup_keys\0");
 
     let data = DkgKeys.backup_keys()?;
@@ -32,29 +31,8 @@ pub fn handler_dkg_backup_keys(comm: &mut Comm) -> Result<(), AppSW> {
 
     let resp = encrypt(&key, data)?;
 
-    send_apdu_chunks(comm, resp)
-}
-
-#[inline(never)]
-fn send_apdu_chunks(comm: &mut Comm, data_vec: Vec<u8>) -> Result<(), AppSW> {
-    zlog_stack("start send_apdu_chunks\0");
-
-    let data = data_vec.as_slice();
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        zlog_stack("iter send_apdu_chunks\0");
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            zlog_stack("another send_apdu_chunks\0");
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgBackupKeys) => {}
-                _ => {}
-            }
-        }
-    }
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
 
     Ok(())
 }

--- a/src/handlers/dkg_commitments.rs
+++ b/src/handlers/dkg_commitments.rs
@@ -20,14 +20,13 @@ use crate::bolos::zlog_stack;
 use crate::context::TxContext;
 use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
+use crate::utils::response::save_result;
 use crate::{AppSW, Instruction};
 use alloc::vec::Vec;
 use ironfish_frost::frost::round1::SigningCommitments;
 use ironfish_frost::nonces::deterministic_signing_nonces;
 use ironfish_frost::participant::Identity;
 use ledger_device_sdk::io::{Comm, Event};
-use crate::utils::response::save_result;
-
 
 const IDENTITY_LEN: usize = 129;
 const TX_HASH_LEN: usize = 32;

--- a/src/handlers/dkg_commitments.rs
+++ b/src/handlers/dkg_commitments.rs
@@ -22,14 +22,13 @@ use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
 use crate::{AppSW, Instruction};
 use alloc::vec::Vec;
-use ironfish_frost::frost::keys::KeyPackage;
 use ironfish_frost::frost::round1::SigningCommitments;
 use ironfish_frost::nonces::deterministic_signing_nonces;
 use ironfish_frost::participant::Identity;
-use ironfish_frost::signing_commitment;
 use ledger_device_sdk::io::{Comm, Event};
+use crate::utils::response::save_result;
 
-const MAX_APDU_SIZE: usize = 253;
+
 const IDENTITY_LEN: usize = 129;
 const TX_HASH_LEN: usize = 32;
 
@@ -52,9 +51,11 @@ pub fn handler_dkg_commitments(
     let nonces = deterministic_signing_nonces(key_package.signing_share(), tx_hash, &identities);
 
     let signing_commitment: SigningCommitments = (&nonces).into();
-    let ser = signing_commitment.serialize().unwrap();
+    let resp = signing_commitment.serialize().unwrap();
 
-    send_apdu_chunks(comm, ser)
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
+    Ok(())
 }
 
 #[inline(never)]
@@ -82,28 +83,4 @@ fn parse_tx(buffer: &Buffer) -> Result<(Vec<Identity>, &[u8]), AppSW> {
     }
 
     Ok((identities, tx_hash))
-}
-
-#[inline(never)]
-fn send_apdu_chunks(comm: &mut Comm, data_vec: Vec<u8>) -> Result<(), AppSW> {
-    zlog_stack("start send_apdu_chunks\0");
-
-    let data = data_vec.as_slice();
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        zlog_stack("iter send_apdu_chunks\0");
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            zlog_stack("another send_apdu_chunks\0");
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgCommitments { chunk: 0 }) => {}
-                _ => {}
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/src/handlers/dkg_get_keys.rs
+++ b/src/handlers/dkg_get_keys.rs
@@ -22,7 +22,6 @@ use crate::{AppSW};
 use alloc::vec::Vec;
 use ledger_device_sdk::io::{Comm};
 use crate::context::TxContext;
-use crate::utils::response::save_result;
 
 
 #[inline(never)]
@@ -44,8 +43,7 @@ pub fn handler_dkg_get_keys(comm: &mut Comm, key_type: &u8,
     let resp = get_requested_keys(&account_keys, key_type)?;
     drop(account_keys);
 
-    let total_chunks = save_result(ctx, resp.as_slice())?;
-    comm.append(&total_chunks);
+    comm.append(resp.as_slice().as_ref());
     Ok(())
 }
 

--- a/src/handlers/dkg_get_keys.rs
+++ b/src/handlers/dkg_get_keys.rs
@@ -18,17 +18,16 @@
 use crate::bolos::zlog_stack;
 use crate::ironfish::multisig::{derive_account_keys, MultisigAccountKeys};
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW, Instruction};
+use crate::{AppSW};
 use alloc::vec::Vec;
-use ironfish_frost::dkg::group_key::{GroupSecretKey, GROUP_SECRET_KEY_LEN};
-use ironfish_frost::dkg::round3::PublicKeyPackage;
-use ironfish_frost::frost::keys::PublicKeyPackage as FrostPublicKeyPackage;
-use ledger_device_sdk::io::{Comm, Event};
+use ledger_device_sdk::io::{Comm};
+use crate::context::TxContext;
+use crate::utils::response::save_result;
 
-const MAX_APDU_SIZE: usize = 253;
 
 #[inline(never)]
-pub fn handler_dkg_get_keys(comm: &mut Comm, key_type: &u8) -> Result<(), AppSW> {
+pub fn handler_dkg_get_keys(comm: &mut Comm, key_type: &u8,
+                            ctx: &mut TxContext) -> Result<(), AppSW> {
     zlog_stack("start handler_dkg_get_keys\0");
 
     let group_secret_key = DkgKeys.load_group_secret_key()?;
@@ -45,7 +44,9 @@ pub fn handler_dkg_get_keys(comm: &mut Comm, key_type: &u8) -> Result<(), AppSW>
     let resp = get_requested_keys(&account_keys, key_type)?;
     drop(account_keys);
 
-    send_apdu_chunks(comm, resp.as_slice())
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
+    Ok(())
 }
 
 #[inline(never)]
@@ -80,25 +81,4 @@ fn get_requested_keys(account_keys: &MultisigAccountKeys, key_type: &u8) -> Resu
         }
         _ => Err(AppSW::InvalidKeyType),
     }
-}
-
-#[inline(never)]
-fn send_apdu_chunks(comm: &mut Comm, data: &[u8]) -> Result<(), AppSW> {
-    zlog_stack("start send_apdu_chunks\0");
-
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgGetKeys { key_type: 0 }) => {}
-                _ => {}
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/src/handlers/dkg_get_keys.rs
+++ b/src/handlers/dkg_get_keys.rs
@@ -16,17 +16,19 @@
  *****************************************************************************/
 
 use crate::bolos::zlog_stack;
+use crate::context::TxContext;
 use crate::ironfish::multisig::{derive_account_keys, MultisigAccountKeys};
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW};
+use crate::AppSW;
 use alloc::vec::Vec;
-use ledger_device_sdk::io::{Comm};
-use crate::context::TxContext;
-
+use ledger_device_sdk::io::Comm;
 
 #[inline(never)]
-pub fn handler_dkg_get_keys(comm: &mut Comm, key_type: &u8,
-                            ctx: &mut TxContext) -> Result<(), AppSW> {
+pub fn handler_dkg_get_keys(
+    comm: &mut Comm,
+    key_type: &u8,
+    ctx: &mut TxContext,
+) -> Result<(), AppSW> {
     zlog_stack("start handler_dkg_get_keys\0");
 
     let group_secret_key = DkgKeys.load_group_secret_key()?;

--- a/src/handlers/dkg_get_public_package.rs
+++ b/src/handlers/dkg_get_public_package.rs
@@ -16,13 +16,12 @@
  *****************************************************************************/
 
 use crate::bolos::zlog_stack;
-use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW};
-use ironfish_frost::dkg::round3::PublicKeyPackage;
-use ledger_device_sdk::io::{Comm};
 use crate::context::TxContext;
+use crate::nvm::dkg_keys::DkgKeys;
 use crate::utils::response::save_result;
-
+use crate::AppSW;
+use ironfish_frost::dkg::round3::PublicKeyPackage;
+use ledger_device_sdk::io::Comm;
 
 #[inline(never)]
 pub fn handler_dkg_get_public_package(comm: &mut Comm, ctx: &mut TxContext) -> Result<(), AppSW> {

--- a/src/handlers/dkg_get_public_package.rs
+++ b/src/handlers/dkg_get_public_package.rs
@@ -16,20 +16,17 @@
  *****************************************************************************/
 
 use crate::bolos::zlog_stack;
-use crate::ironfish::multisig::{derive_account_keys, MultisigAccountKeys};
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW, Instruction};
-use alloc::vec::Vec;
-use ironfish_frost::dkg::group_key::{GroupSecretKey, GROUP_SECRET_KEY_LEN};
+use crate::{AppSW};
 use ironfish_frost::dkg::round3::PublicKeyPackage;
-use ironfish_frost::frost::keys::PublicKeyPackage as FrostPublicKeyPackage;
-use ledger_device_sdk::io::{Comm, Event};
+use ledger_device_sdk::io::{Comm};
+use crate::context::TxContext;
+use crate::utils::response::save_result;
 
-const MAX_APDU_SIZE: usize = 253;
 
 #[inline(never)]
-pub fn handler_dkg_get_public_package(comm: &mut Comm) -> Result<(), AppSW> {
-    zlog_stack("start handler_dkg_get_public_package\0");
+pub fn handler_dkg_get_public_package(comm: &mut Comm, ctx: &mut TxContext) -> Result<(), AppSW> {
+    zlog_stack("start handler_dkg_get_pub_pack\0");
 
     let identities = DkgKeys.load_identities()?;
     let min_signers = DkgKeys.load_min_signers()?;
@@ -39,26 +36,8 @@ pub fn handler_dkg_get_public_package(comm: &mut Comm) -> Result<(), AppSW> {
 
     let resp = p.serialize();
 
-    send_apdu_chunks(comm, resp.as_slice())
-}
-
-#[inline(never)]
-fn send_apdu_chunks(comm: &mut Comm, data: &[u8]) -> Result<(), AppSW> {
-    zlog_stack("start send_apdu_chunks\0");
-
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgGetPublicPackage) => {}
-                _ => {}
-            }
-        }
-    }
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
 
     Ok(())
 }

--- a/src/handlers/dkg_nonces.rs
+++ b/src/handlers/dkg_nonces.rs
@@ -20,12 +20,12 @@ use crate::bolos::zlog_stack;
 use crate::context::TxContext;
 use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW};
+use crate::utils::response::save_result;
+use crate::AppSW;
 use alloc::vec::Vec;
 use ironfish_frost::nonces::deterministic_signing_nonces;
 use ironfish_frost::participant::Identity;
-use ledger_device_sdk::io::{Comm};
-use crate::utils::response::save_result;
+use ledger_device_sdk::io::Comm;
 
 const IDENTITY_LEN: usize = 129;
 const TX_HASH_LEN: usize = 32;

--- a/src/handlers/dkg_round_1.rs
+++ b/src/handlers/dkg_round_1.rs
@@ -21,14 +21,14 @@ use crate::context::TxContext;
 use crate::handlers::dkg_get_identity::compute_dkg_secret;
 use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW, Instruction};
+use crate::{AppSW};
 use alloc::vec::Vec;
 use ironfish_frost::dkg;
 use ironfish_frost::participant::{Identity, Secret};
-use ledger_device_sdk::io::{Comm, Event};
+use ledger_device_sdk::io::{Comm};
 use ledger_device_sdk::random::LedgerRng;
+use crate::utils::response::save_result;
 
-const MAX_APDU_SIZE: usize = 253;
 const IDENTITY_LEN: usize = 129;
 
 pub struct Tx {
@@ -49,9 +49,13 @@ pub fn handler_dkg_round_1(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> R
     let mut tx: Tx = parse_tx(&ctx.buffer)?;
     let dkg_secret = compute_dkg_secret(tx.identity_index);
 
-    compute_dkg_round_1(comm, &dkg_secret, &mut tx)?;
+    let resp = compute_dkg_round_1(comm, &dkg_secret, &mut tx)?;
 
-    DkgKeys.save_round_1_data(&tx.identities, tx.min_signers)
+    DkgKeys.save_round_1_data(&tx.identities, tx.min_signers)?;
+
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
+    Ok(())
 }
 
 fn parse_tx(buffer: &Buffer) -> Result<Tx, AppSW> {
@@ -86,7 +90,7 @@ fn parse_tx(buffer: &Buffer) -> Result<Tx, AppSW> {
     })
 }
 
-fn compute_dkg_round_1(comm: &mut Comm, secret: &Secret, tx: &mut Tx) -> Result<(), AppSW> {
+fn compute_dkg_round_1(comm: &mut Comm, secret: &Secret, tx: &mut Tx) -> Result<Vec<u8>, AppSW> {
     zlog("start compute_dkg_round_1\n\0");
 
     let mut rng = LedgerRng {};
@@ -121,25 +125,5 @@ fn compute_dkg_round_1(comm: &mut Comm, secret: &Secret, tx: &mut Tx) -> Result<
     );
     resp.append(&mut round1_public_package_vec);
 
-    send_apdu_chunks(comm, resp.as_slice())?;
-
-    Ok(())
-}
-
-fn send_apdu_chunks(comm: &mut Comm, data: &[u8]) -> Result<(), AppSW> {
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgRound1 { chunk: 0 }) => {}
-                _ => {}
-            }
-        }
-    }
-
-    Ok(())
+    Ok(resp)
 }

--- a/src/handlers/dkg_round_1.rs
+++ b/src/handlers/dkg_round_1.rs
@@ -21,13 +21,13 @@ use crate::context::TxContext;
 use crate::handlers::dkg_get_identity::compute_dkg_secret;
 use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW};
+use crate::utils::response::save_result;
+use crate::AppSW;
 use alloc::vec::Vec;
 use ironfish_frost::dkg;
 use ironfish_frost::participant::{Identity, Secret};
-use ledger_device_sdk::io::{Comm};
+use ledger_device_sdk::io::Comm;
 use ledger_device_sdk::random::LedgerRng;
-use crate::utils::response::save_result;
 
 const IDENTITY_LEN: usize = 129;
 

--- a/src/handlers/dkg_round_2.rs
+++ b/src/handlers/dkg_round_2.rs
@@ -20,15 +20,14 @@ use crate::bolos::zlog_stack;
 use crate::context::TxContext;
 use crate::handlers::dkg_get_identity::compute_dkg_secret;
 use crate::nvm::buffer::Buffer;
-use crate::{AppSW};
+use crate::utils::response::save_result;
+use crate::AppSW;
 use alloc::vec::Vec;
 use ironfish_frost::dkg;
 use ironfish_frost::dkg::round1::PublicPackage;
 use ironfish_frost::dkg::round2::CombinedPublicPackage;
-use ledger_device_sdk::io::{Comm};
+use ledger_device_sdk::io::Comm;
 use ledger_device_sdk::random::LedgerRng;
-use crate::utils::response::save_result;
-
 
 #[inline(never)]
 pub fn handler_dkg_round_2(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> Result<(), AppSW> {

--- a/src/handlers/dkg_round_2.rs
+++ b/src/handlers/dkg_round_2.rs
@@ -20,18 +20,15 @@ use crate::bolos::zlog_stack;
 use crate::context::TxContext;
 use crate::handlers::dkg_get_identity::compute_dkg_secret;
 use crate::nvm::buffer::Buffer;
-use crate::{AppSW, Instruction};
+use crate::{AppSW};
 use alloc::vec::Vec;
 use ironfish_frost::dkg;
 use ironfish_frost::dkg::round1::PublicPackage;
 use ironfish_frost::dkg::round2::CombinedPublicPackage;
-use ironfish_frost::error::IronfishFrostError;
-use ironfish_frost::participant::Secret;
-use ledger_device_sdk::io::{Comm, Event};
+use ledger_device_sdk::io::{Comm};
 use ledger_device_sdk::random::LedgerRng;
-use serde_json_core::to_string;
+use crate::utils::response::save_result;
 
-const MAX_APDU_SIZE: usize = 253;
 
 #[inline(never)]
 pub fn handler_dkg_round_2(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> Result<(), AppSW> {
@@ -53,11 +50,13 @@ pub fn handler_dkg_round_2(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> R
         round_1_secret_package,
     )?;
 
-    let response = generate_response(&mut round2_secret_package_vec, &round2_public_package);
+    let resp = generate_response(&mut round2_secret_package_vec, &round2_public_package);
     drop(round2_secret_package_vec);
     drop(round2_public_package);
 
-    send_apdu_chunks(comm, &response)
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
+    Ok(())
 }
 
 #[inline(never)]
@@ -149,24 +148,4 @@ fn generate_response(
     resp.append(&mut round2_public_package_vec);
 
     resp
-}
-
-#[inline(never)]
-fn send_apdu_chunks(comm: &mut Comm, data_vec: &Vec<u8>) -> Result<(), AppSW> {
-    let data = data_vec.as_slice();
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgRound2 { chunk: 0 }) => {}
-                _ => {}
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/src/handlers/dkg_sign.rs
+++ b/src/handlers/dkg_sign.rs
@@ -20,13 +20,12 @@ use crate::bolos::zlog_stack;
 use crate::context::TxContext;
 use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW};
+use crate::utils::response::save_result;
+use crate::AppSW;
 use ironfish_frost::frost::round1::SigningNonces;
 use ironfish_frost::frost::round2;
 use ironfish_frost::{frost::Randomizer, frost::SigningPackage};
-use ledger_device_sdk::io::{Comm};
-use crate::utils::response::save_result;
-
+use ledger_device_sdk::io::Comm;
 
 #[inline(never)]
 pub fn handler_dkg_sign(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> Result<(), AppSW> {

--- a/src/handlers/dkg_sign.rs
+++ b/src/handlers/dkg_sign.rs
@@ -20,15 +20,13 @@ use crate::bolos::zlog_stack;
 use crate::context::TxContext;
 use crate::nvm::buffer::Buffer;
 use crate::nvm::dkg_keys::DkgKeys;
-use crate::{AppSW, Instruction};
-use alloc::vec::Vec;
-use ironfish_frost::frost::keys::KeyPackage;
+use crate::{AppSW};
 use ironfish_frost::frost::round1::SigningNonces;
 use ironfish_frost::frost::round2;
 use ironfish_frost::{frost::Randomizer, frost::SigningPackage};
-use ledger_device_sdk::io::{Comm, Event};
+use ledger_device_sdk::io::{Comm};
+use crate::utils::response::save_result;
 
-const MAX_APDU_SIZE: usize = 253;
 
 #[inline(never)]
 pub fn handler_dkg_sign(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> Result<(), AppSW> {
@@ -46,9 +44,11 @@ pub fn handler_dkg_sign(comm: &mut Comm, chunk: u8, ctx: &mut TxContext) -> Resu
     let signature = round2::sign(&frost_signing_package, &nonces, &key_package, randomizer);
 
     zlog_stack("unwrap sig result\0");
-    let sig = signature.unwrap().serialize();
+    let resp = signature.unwrap().serialize();
 
-    send_apdu_chunks(comm, sig)
+    let total_chunks = save_result(ctx, resp.as_slice())?;
+    comm.append(&total_chunks);
+    Ok(())
 }
 
 #[inline(never)]
@@ -84,26 +84,4 @@ fn parse_tx(buffer: &Buffer) -> Result<(SigningPackage, SigningNonces, Randomize
     }
 
     Ok((frost_signing_package, nonces, randomizer))
-}
-
-#[inline(never)]
-fn send_apdu_chunks(comm: &mut Comm, data_vec: Vec<u8>) -> Result<(), AppSW> {
-    zlog_stack("start send_apdu_chunks\0");
-
-    let data = data_vec.as_slice();
-    let total_chunks = (data.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE;
-
-    for (i, chunk) in data.chunks(MAX_APDU_SIZE).enumerate() {
-        comm.append(chunk);
-
-        if i < total_chunks - 1 {
-            comm.reply_ok();
-            match comm.next_event() {
-                Event::Command(Instruction::DkgSign { chunk: 0 }) => {}
-                _ => {}
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/src/handlers/get_result.rs
+++ b/src/handlers/get_result.rs
@@ -15,18 +15,18 @@
  *  limitations under the License.
  *****************************************************************************/
 
+use crate::context::TxContext;
 use crate::AppSW;
 use ledger_device_sdk::io::Comm;
-use crate::context::TxContext;
 
 const MAX_APDU_SIZE: usize = 253;
 
 #[inline(never)]
 pub fn handler_get_result(comm: &mut Comm, ctx: &mut TxContext, page: u8) -> Result<(), AppSW> {
-    let start_page_pos:usize = page as usize * MAX_APDU_SIZE;
-    let mut end_page_pos:usize = start_page_pos + MAX_APDU_SIZE;
+    let start_page_pos: usize = page as usize * MAX_APDU_SIZE;
+    let mut end_page_pos: usize = start_page_pos + MAX_APDU_SIZE;
 
-    if ctx.buffer.pos < end_page_pos{
+    if ctx.buffer.pos < end_page_pos {
         end_page_pos = ctx.buffer.pos;
     }
 

--- a/src/handlers/get_result.rs
+++ b/src/handlers/get_result.rs
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ *   Ledger App Ironfish Rust.
+ *   (c) 2023 Ledger SAS.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************/
+
+use crate::AppSW;
+use ledger_device_sdk::io::Comm;
+use crate::context::TxContext;
+
+const MAX_APDU_SIZE: usize = 253;
+
+#[inline(never)]
+pub fn handler_get_result(comm: &mut Comm, ctx: &mut TxContext, page: u8) -> Result<(), AppSW> {
+    let start_page_pos:usize = page as usize * MAX_APDU_SIZE;
+    let mut end_page_pos:usize = start_page_pos + MAX_APDU_SIZE;
+
+    if ctx.buffer.pos < end_page_pos{
+        end_page_pos = ctx.buffer.pos;
+    }
+
+    let data_to_send = ctx.buffer.get_slice(start_page_pos, end_page_pos)?;
+    comm.append(data_to_send);
+
+    Ok(())
+}

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -16,6 +16,7 @@ pub enum Instruction {
     DkgNonces { chunk: u8 },
     DkgBackupKeys,
     DkgRestoreKeys { chunk: u8 },
+    GetResult { chunk: u8 },
 }
 
 impl TryFrom<ApduHeader> for Instruction {
@@ -47,6 +48,7 @@ impl TryFrom<ApduHeader> for Instruction {
             (24, 0..=2, 0) => Ok(Instruction::DkgGetPublicPackage),
             (25, 0, 0) => Ok(Instruction::DkgBackupKeys),
             (26, 0..=2, 0) => Ok(Instruction::DkgRestoreKeys { chunk: value.p1 }),
+            (27, 0..=255, 0) => Ok(Instruction::GetResult  { chunk: value.p1 }),
             (3..=4, _, _) => Err(AppSW::WrongP1P2),
             (17..=26, _, _) => Err(AppSW::WrongP1P2),
             (_, _, _) => Err(AppSW::InsNotSupported),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -48,7 +48,7 @@ impl TryFrom<ApduHeader> for Instruction {
             (24, 0..=2, 0) => Ok(Instruction::DkgGetPublicPackage),
             (25, 0, 0) => Ok(Instruction::DkgBackupKeys),
             (26, 0..=2, 0) => Ok(Instruction::DkgRestoreKeys { chunk: value.p1 }),
-            (27, 0..=255, 0) => Ok(Instruction::GetResult  { chunk: value.p1 }),
+            (27, 0..=255, 0) => Ok(Instruction::GetResult { chunk: value.p1 }),
             (3..=4, _, _) => Err(AppSW::WrongP1P2),
             (17..=26, _, _) => Err(AppSW::WrongP1P2),
             (_, _, _) => Err(AppSW::InsNotSupported),

--- a/src/nvm/buffer.rs
+++ b/src/nvm/buffer.rs
@@ -74,7 +74,7 @@ impl Buffer {
 
     #[inline(never)]
     #[allow(unused)]
-    pub fn set_slice(&self, mut index: usize, value: &[u8]) -> Result<(), AppSW> {
+    pub fn set_slice(&mut self, mut index: usize, value: &[u8]) -> Result<(), AppSW> {
         let mut updated_data: [u8; BUFFER_SIZE] = unsafe { *DATA.get_mut().get_ref() };
         for b in value.iter() {
             self.check_write_pos(index)?;
@@ -85,8 +85,9 @@ impl Buffer {
         unsafe {
             DATA.get_mut().update(&updated_data);
         }
-
         self.is_valid_write()?;
+
+        self.pos += value.len();
         Ok(())
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
 mod bip32;
+pub mod response;
+
 pub use bip32::Bip32Path;
 use core::cmp;
 

--- a/src/utils/response.rs
+++ b/src/utils/response.rs
@@ -1,0 +1,13 @@
+use crate::AppSW;
+use crate::context::TxContext;
+
+const MAX_APDU_SIZE: usize = 253;
+
+#[inline(never)]
+pub fn save_result(ctx: &mut TxContext, resp: &[u8]) -> Result<[u8;1], AppSW>{
+    ctx.reset();
+    ctx.buffer.set_slice(0, resp)?;
+
+    let total_chunks = [((resp.len() + MAX_APDU_SIZE - 1) /MAX_APDU_SIZE) as u8];
+    Ok(total_chunks)
+}

--- a/src/utils/response.rs
+++ b/src/utils/response.rs
@@ -1,13 +1,13 @@
-use crate::AppSW;
 use crate::context::TxContext;
+use crate::AppSW;
 
 const MAX_APDU_SIZE: usize = 253;
 
 #[inline(never)]
-pub fn save_result(ctx: &mut TxContext, resp: &[u8]) -> Result<[u8;1], AppSW>{
+pub fn save_result(ctx: &mut TxContext, resp: &[u8]) -> Result<[u8; 1], AppSW> {
     ctx.reset();
     ctx.buffer.set_slice(0, resp)?;
 
-    let total_chunks = [((resp.len() + MAX_APDU_SIZE - 1) /MAX_APDU_SIZE) as u8];
+    let total_chunks = [((resp.len() + MAX_APDU_SIZE - 1) / MAX_APDU_SIZE) as u8];
     Ok(total_chunks)
 }


### PR DESCRIPTION
this fixes some race condition observed between events when fetching the actual result using comm.next_event() method