### PR TITLE
feat: set opt-level based on device model

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -38,12 +38,20 @@ educe = { version = "0.6.0" }
 arrayref = { version = "0.3.8", default-features = false }
 aead = "0.5.2"
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
+
 [profile.release]
-# changed from z (default on template) to s in order to reduce stack size
-# it will increase the binary size, but it is something we can afford here
-opt-level = "s"
 lto = true
 
+# The opt-level is set based on the device model because stack and binary size. While flex and stax has
+# 44K of SRAM, Nanos2 and NanoX have 40K. That difference makes necessary an opt-level s for nano x and nano s2,
+# because stack size is not enough otherwise.
+# In the other hand, stax and flex should use z. They have more stack, but the app won't fit otherwise. The screen libs
+# are heavier, and the app with clear signing won't fit.
+
+# Opt-leve z optimize the size more, making the app less performant (consumes more stack)
+# Opt-leve s optimize the size, but not that much, making the app a bit more performant (consumes less stack)
+
+# From testing on Nano S2...
 # heap 15k, opt-level=z -> 3 participants fail on signing because of heap fragmentation, app size XXX
 # heap 16.3k, opt-level=s -> 3 participants work, app size 680K
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -88,23 +88,23 @@ include $(CURDIR)/../deps/ledger-zxlib/makefiles/Makefile.side_loading
 
 .PHONY: buildX
 buildX:
-	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) cargo +nightly-2023-11-10  ledger build nanox
+	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) RUSTFLAGS="-C opt-level=s" cargo +nightly-2023-11-10  ledger build nanox
 	FOLDER=nanox make post-build
 
 .PHONY: buildS2
 buildS2:
-	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) cargo +nightly-2023-11-10  ledger build nanosplus
+	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) RUSTFLAGS="-C opt-level=s" cargo +nightly-2023-11-10  ledger build nanosplus
 	FOLDER=nanosplus make post-build
 
 .PHONY: buildST
 buildST:
-	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) cargo +nightly-2023-11-10  ledger build stax
+	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) RUSTFLAGS="-C opt-level=z" cargo +nightly-2023-11-10  ledger build stax
 	FOLDER=stax make post-build
 
 
 .PHONY: buildFL
 buildFL:
-	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) cargo +nightly-2023-11-10  ledger build flex
+	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) RUSTFLAGS="-C opt-level=z" cargo +nightly-2023-11-10  ledger build flex
 	FOLDER=flex make post-build
 
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -86,11 +86,6 @@ endif
 
 include $(CURDIR)/../deps/ledger-zxlib/makefiles/Makefile.side_loading
 
-.PHONY: buildS
-buildS:
-	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) cargo +nightly-2023-11-10 ledger build nanos
-	FOLDER=nanos make post-build
-
 .PHONY: buildX
 buildX:
 	APPVERSION_STR=$(APPVERSION_STR) PRODUCTION_BUILD=$(PRODUCTION_BUILD) cargo +nightly-2023-11-10  ledger build nanox


### PR DESCRIPTION
The opt-level is set based on the device model because stack and binary size. While flex and stax has
44K of SRAM, Nanos2 and NanoX have 40K. That difference makes necessary an opt-level s for nano x and nano s2, because stack size is not enough otherwise.
In the other hand, stax and flex should use z. They have more stack, but the app won't fit otherwise. The screen libs
are heavier, and the app with clear signing won't fit.

- Opt-leve z optimize the size more, making the app less performant (consumes more stack)
- Opt-leve s optimize the size, but not that much, making the app a bit more performant (consumes less stack)

### From testing on Nano S2...
- heap 15k, opt-level=z -> 3 participants fail on signing because of heap fragmentation, app size XXX
- heap 16.3k, opt-level=s -> 3 participants work, app size 680K